### PR TITLE
Added visibility rule to StorageContainerName input

### DIFF
--- a/Xpirit-Vsts-Release-Terraform/task.json
+++ b/Xpirit-Vsts-Release-Terraform/task.json
@@ -106,7 +106,8 @@
       "properties": {
         "EditableOptions": "True"
       },
-      "helpMarkDown": "Enter the name the Blob container within the given StorageAccount."
+      "helpMarkDown": "Enter the name the Blob container within the given StorageAccount.",
+      "visibleRule": "ManageState == true"
     }
   ],
   "dataSourceBindings": [


### PR DESCRIPTION
When the option "Manage state in blobstorage" is not selected, terraforming fails with ##[error]Required: 'ConnectedServiceNameARM' input.