### PR TITLE
Cannot use output command because -input and -no-color options are not allowed.

### DIFF
--- a/Xpirit-Vsts-Release-Terraform/terraform.ps1
+++ b/Xpirit-Vsts-Release-Terraform/terraform.ps1
@@ -125,11 +125,18 @@ function Initialize-Terraform
     }
     
     $additionalArguments = Get-VstsInput -Name InitArguments
+
+    $extraArguments = " -input=false -no-color"
+
+    if ($additionalArguments.Trim() -like "output*") {
+        $extraArguments = "";
+    }
+
     if (-not ([string]::IsNullOrEmpty($additionalArguments)))
     {
-        $arguments = $remoteStateArguments + " $($additionalArguments.Trim()) -input=false -no-color"
+        $arguments = $remoteStateArguments + " $($additionalArguments.Trim()) $($extraArguments.Trim())"
     } else {
-        $arguments = $remoteStateArguments + " -input=false -no-color"
+        $arguments = $remoteStateArguments + " $($extraArguments.Trim())"
     }
        
     Invoke-VstsTool -FileName terraform -arguments "init $arguments"


### PR DESCRIPTION
Cannot use output command because -input and -no-color options are not allowed:
[https://www.terraform.io/docs/commands/output.html](https://www.terraform.io/docs/commands/output.html)

By allowing this, will be possible to publish outputs JSON formatted and make these available as Azure DevOps variables.