### PR TITLE
Remove default argument for validate

### DIFF
--- a/Xpirit-Vsts-Release-Terraform/terraform.ps1
+++ b/Xpirit-Vsts-Release-Terraform/terraform.ps1
@@ -127,6 +127,10 @@ function Initialize-Terraform
     $additionalArguments = Get-VstsInput -Name InitArguments
 
     $extraArguments = " -input=false -no-color"
+    
+    if ($additionalArguments.Trim() -like "validate*") {
+        $extraArguments = ""
+    }
 
     if ($additionalArguments.Trim() -like "output*") {
         $extraArguments = "";


### PR DESCRIPTION
Under tf 0.12 validate no longer takes `-input=false` and in fact errors out if you do. Fixes #21 