### PR TITLE
Exclude -input=false for workspace commands as well

### DIFF
--- a/Xpirit-Vsts-Release-Terraform/terraform.ps1
+++ b/Xpirit-Vsts-Release-Terraform/terraform.ps1
@@ -155,7 +155,7 @@ function Invoke-Terraform
 
     $defaultArgs = "-input=false -no-color " + (Get-VstsInput -Name PlanPath)
     
-    if ($arguments.Trim() -like "validate*") 
+    if ($arguments.Trim() -like "validate*" -or $arguments.Trim() -like "workspace*") 
     {
         $defaultArgs = "-no-color " + (Get-VstsInput -Name PlanPath)
     }


### PR DESCRIPTION
I have no way of easily testing this but the `-input=false` flag should be excluded from the `workspace` commands as well. I think this should do the trick. See #21