### PR TITLE
Allow providing DIR to `terraform init`

### DIFF
--- a/Xpirit-Vsts-Release-Terraform/terraform.ps1
+++ b/Xpirit-Vsts-Release-Terraform/terraform.ps1
@@ -134,9 +134,9 @@ function Initialize-Terraform
 
     if (-not ([string]::IsNullOrEmpty($additionalArguments)))
     {
-        $arguments = $remoteStateArguments + "$($extraArguments.Trim()) $($additionalArguments.Trim())"
+        $arguments = $remoteStateArguments + "$extraArguments $($additionalArguments.Trim())"
     } else {
-        $arguments = $remoteStateArguments + "$($extraArguments.Trim())"
+        $arguments = $remoteStateArguments + "$extraArguments"
     }
        
     Invoke-VstsTool -FileName terraform -arguments "init $arguments"

--- a/Xpirit-Vsts-Release-Terraform/terraform.ps1
+++ b/Xpirit-Vsts-Release-Terraform/terraform.ps1
@@ -134,9 +134,9 @@ function Initialize-Terraform
 
     if (-not ([string]::IsNullOrEmpty($additionalArguments)))
     {
-        $arguments = $remoteStateArguments + " $($additionalArguments.Trim()) $($extraArguments.Trim())"
+        $arguments = $remoteStateArguments + "$($extraArguments.Trim()) $($additionalArguments.Trim())"
     } else {
-        $arguments = $remoteStateArguments + " $($extraArguments.Trim())"
+        $arguments = $remoteStateArguments + "$($extraArguments.Trim())"
     }
        
     Invoke-VstsTool -FileName terraform -arguments "init $arguments"


### PR DESCRIPTION
The usage is:

```
terraform init [options] [DIR]
```

So if we were to provide a directory to execute `terraform init` in, it would have to be the very last argument.