### PR TITLE
Fix terraform version download

### DIFF
--- a/Xpirit-Vsts-Release-Terraform/terraform.ps1
+++ b/Xpirit-Vsts-Release-Terraform/terraform.ps1
@@ -33,7 +33,7 @@ function Install-Terraform
     $terraformbaseurl = "https://releases.hashicorp.com/terraform/"
     $path = "c:\terraform-download"
 
-    $regex = """/terraform/([0-9]+\.[0-9]+\.[0-9]+)/"""
+    $regex = """/terraform/([0-9]+\.[0-9]+\.[0-9]+)"""
 
     $webpage = (Invoke-WebRequest $terraformbaseurl -UseBasicParsing).Content
 


### PR DESCRIPTION
This is to fix the regex found in https://github.com/XpiritBV/Xpirit-Vsts-Release-Terraform/issues/36 

This has been tested and working with this forked extension - https://marketplace.visualstudio.com/items?itemName=DevKyleS.DevKyleS-Xpirit-Vsts-Release-Terraform